### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/rapidftr/tracker.png?label=ready&title=Ready)](https://waffle.io/rapidftr/tracker)
 # Contributor Quick Start
 
 * Stories for all RapidFTR projects (web, android, infrastructure, guides) are tracked as GitHub Issues in this repository.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/rapidftr/tracker

This was requested by a real person (user tomclement) on waffle.io, we're not trying to spam you.
